### PR TITLE
Crystal 0.24.1

### DIFF
--- a/src/bin/neph_bin.cr
+++ b/src/bin/neph_bin.cr
@@ -87,7 +87,7 @@ class NephBin
 
     loop do
       log_ln "Are you sure you want to uninstall 'neph'? [Y/n]"
-      
+
       if input = STDIN.gets
         case input
         when "Y"

--- a/src/neph.cr
+++ b/src/neph.cr
@@ -3,7 +3,7 @@ require "./neph/*"
 module Neph
   include Neph::Parser
   include Neph::Message
-  
+
   NEPH_DIR = ".neph"
 
   LOG_OUT = "log.out"
@@ -45,19 +45,11 @@ module Neph
     "#{(millis * 1000).round(2)}µs"
   end
 
-  def log_ln(msg : String)
-    log(msg + "\n", false)
-  end
-
-  def log_ln(msg : String, force : Bool)
+  def log_ln(msg : String, force : Bool = false)
     log(msg + "\n", force)
   end
 
-  def log(msg : String)
-    log(msg, false)
-  end
-
-  def log(msg : String, force : Bool)
+  def log(msg : String, force : Bool = false)
     print msg if !@quiet || force
   end
 end

--- a/src/neph/parser/parser.cr
+++ b/src/neph/parser/parser.cr
@@ -44,16 +44,8 @@ module Neph
 
       job = Job.new(job_name, job_command, parent_job)
       job.dir = job_config["dir"].as(String) if job_config.has_key?("dir")
-      job.ignore_error = if job_config["ignore_error"].as(String) == "true"
-                           true
-                         else
-                           false
-                         end if job_config.has_key?("ignore_error")
-      job.hide = if job_config["hide"].as(String) == "true"
-                   true
-                 else
-                   false
-                 end if job_config.has_key?("hide")
+      job.ignore_error = job_config["ignore_error"] ? true : false if job_config.has_key?("ignore_error")
+      job.hide = job_config["hide"] ? true : false if job_config.has_key?("hide")
 
       if job_config.has_key?("src")
         if job_config["src"].is_a?(YArray)

--- a/src/neph/parser/parser.cr
+++ b/src/neph/parser/parser.cr
@@ -12,7 +12,7 @@ module Neph
 
       config
     end
-    
+
     def parse_yaml(job_name : String, path : String) : Job
       config = parse_yaml(path)
 


### PR DESCRIPTION
A small bug with `Bool#as(String)` have been fixed. (It appeared because YAML parsing changed in Crystal 0.24)
With using default values for args, there is no need for declaring two times `Neph#log`, and `Neph#log_ln`.