### PR TITLE
Enable hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
 /doc/
 /lib/
-/bin/
 /.shards/
 /.neph/
-
-.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PREFIX ?= /usr/local
 SHARD_BIN ?= ../../bin
 
 build:
-	$(CRYSTAL_BIN) build --no-debug -o bin/neph src/neph.cr $(CRFLAGS)
+	$(CRYSTAL_BIN) build --no-debug -o bin/neph src/bin/neph_bin.cr $(CRFLAGS)
 clean:
 	rm -f ./bin/neph
 install: build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+CRYSTAL_BIN ?= $(shell which crystal)
+PREFIX ?= /usr/local
+SHARD_BIN ?= ../../bin
+
+build:
+	$(CRYSTAL_BIN) build --no-debug -o bin/neph src/neph.cr $(CRFLAGS)
+clean:
+	rm -f ./bin/neph
+install: build
+	mkdir -p $(PREFIX)/bin
+	cp ./bin/neph $(PREFIX)/bin
+bin: build
+	mkdir -p $(SHARD_BIN)
+	cp ./bin/neph $(SHARD_BIN)
+test: build
+	$(CRYSTAL_BIN) spec
+	./bin/neph
+man: build
+	./bin/neph man

--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,0 +1,1 @@
+!.gitignore

--- a/shard.yml
+++ b/shard.yml
@@ -8,6 +8,12 @@ targets:
     neph:
       main: src/bin/neph_bin.cr
 
+scripts:
+  postinstall: make bin
+
 crystal: 0.24.2
 
 license: MIT
+
+executables:
+  - neph

--- a/shard.yml
+++ b/shard.yml
@@ -8,6 +8,6 @@ targets:
     neph:
       main: src/bin/neph_bin.cr
 
-crystal: 0.23.1
+crystal: 0.24.2
 
 license: MIT


### PR DESCRIPTION
Hi,

When creating `release` via `shards build`, it could be helpful (to be a **de-facto** standard in `crystal` as `rake` is in `ruby) to have `neph` installed

In order to have `bin/neph`, I've add following in my `shard.yml`

~~~yaml
development_dependencies:
  neph:
    github: tbrand/neph
~~~

Regards,

PS : Original idea by https://veelenga.github.io/ameba/

