### PR TITLE
Sequential execution and before/after command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 </p>
 
 - A modern command line job processor written in Crystal :rocket:
-- Can execute jobs concurrently. :rocket:
-- Can be substitute for `make` command. :rocket:
+- Parallel job execution. :rocket:
+- Use like `make` command. :rocket:
 
 ## Installation
 

--- a/neph.yaml
+++ b/neph.yaml
@@ -4,22 +4,22 @@ main:
     - binary
 
 binary:
-  command:
-    shards build --release
+  commands:
+    - shards build --release
   src:
     - src/**/*.cr
 
 test:
-  command:
-    crystal spec
+  commands:
+    - crystal spec
 
 man:
   ignore_error: true
-  command:
-    go-md2man -in neph.1.md -out neph.1
+  commands:
+    - go-md2man -in neph.1.md -out neph.1
 
 clean:
-  command:
-    rm -f bin/neph
-    rm -f neph.1
-    rm -fd bin
+  commands:
+    - rm -f bin/neph
+    - rm -f neph.1
+    - rm -fd bin

--- a/sample/in_readme.yaml
+++ b/sample/in_readme.yaml
@@ -1,37 +1,37 @@
 main:
-  command:
-    sleep 0.8
+  commands:
+    - sleep 0.8
   depends_on:
     - sub_job0
     - sub_job1
     - sub_job2
 
 sub_job0:
-  command:
-    sleep 1
+  commands:
+    - sleep 1
   depends_on:
     - sub_sub_job0
     - sub_sub_job1
 
 sub_job1:
-  command: |
-    sleep 0.8
-    sleep 1.2
+  commands:
+    - sleep 0.8
+    - sleep 1.2
   depends_on:
     sub_sub_job2
 
 sub_job2:
-  command:
-    sleep 1.4
+  commands:
+    - sleep 1.4
 
 sub_sub_job0:
-  command:
-    sleep 0.6
+  commands:
+    - sleep 0.6
 
 sub_sub_job1:
-  command:
-    sleep 0.8
+  commands:
+    - sleep 0.8
 
 sub_sub_job2:
-  command:
-    sleep 1
+  commands:
+    - sleep 1

--- a/sample/neph.yaml
+++ b/sample/neph.yaml
@@ -3,39 +3,45 @@ import:
   sample/outside_configuration.yaml
 
 main:
-  command: |
-    echo "This is a Main job!!"
-    echo "Main job depends on sub_job"
-    sleep 0.2
+  commands:
+    - echo "This is a Main job"
+    - echo "Main job depends on sub_job"
+    - sleep 0.2
   depends_on:
     sub_job
 
 sub_job:
-  command: |
-    echo "This is a sub job for main job"
-    echo "You can define multiple dependencies like this"
-    sleep 0.2
+  before:
+    - echo "This is before what I do"
+    - sleep 1
+  after:
+    - echo "This is after what I do"
+    - sleep 1
+  commands:
+    - echo "This is a sub job for main job"
+    - echo "You can define multiple dependencies like this"
+    - sleep 0.2
   depends_on:
     - sub_sub_job0
     - sub_sub_job1
 
 sub_sub_job0:
-  command: |
-    echo "Working on ./sample directory"
-    pwd
-    echo "Check the 'pwd' result at .neph/sub_sub_job0/log/log.out"
-    sleep 0.2
+  commands:
+    - echo "Working on ./sample directory"
+    - pwd
+    - echo "Check the 'pwd' result at .neph/sub_sub_job0/log/log.out"
+    - sleep 0.2
   dir:
     sample
   depends_on:
     - hide_command
 
 sub_sub_job1:
-  command: |
-    echo "This job raises an error since 'hoge' command doesn't exist"
-    echo "But job will proceed since the error will be ignored"
-    sleep 0.2
-    hoge
+  commands:
+    - echo "This job raises an error since 'hoge' command doesn't exist"
+    - echo "But job will proceed since the error will be ignored"
+    - sleep 0.2
+    - hoge
   ignore_error:
     true
   depends_on:
@@ -43,31 +49,31 @@ sub_sub_job1:
     - print_result
 
 specify_sources:
-  command: |
-    echo "This job will not be triggered if the sources are not updated"
-    echo "The feature is inspired by make command"
-    echo "'outside_job' is defined at sample/outside_configuration.yaml"
-    sleep 0.2
+  commands:
+    - echo "This job will not be triggered if the sources are not updated"
+    - echo "The feature is inspired by make command"
+    - echo "'outside_job' is defined at sample/outside_configuration.yaml"
+    - sleep 0.2
   src:
     - src/**/*.cr
   depends_on:
     outside_job
 
 print_result:
-  command:
-    echo "The result is $RESULT!"
+  commands:
+    - echo "The result is $RESULT"
   depends_on:
     -
       job: crystal_eval_job
       env: RESULT
 
 hide_command:
-  command: |
-    sleep 1
-    echo "Can you see me?"
+  commands:
+    - sleep 1
+    - echo "Can you see me?"
   hide:
     true
 
 crystal_eval_job:
-  command:
-    crystal eval 'print 1 + 5'
+  commands:
+    - crystal eval 'print 1 + 5'

--- a/sample/outside_configuration.yaml
+++ b/sample/outside_configuration.yaml
@@ -1,4 +1,4 @@
 outside_job:
-  command: |
-    echo "This is outside job!!"
-    sleep 0.2
+  commands:
+    - echo "This is outside job!!"
+    - sleep 0.2

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: neph
-version: 0.2.6
+version: 0.2.7
 
 authors:
   - Taichiro Suzuki <taichiro0709@gmail.com>
@@ -8,6 +8,6 @@ targets:
     neph:
       main: src/bin/neph_bin.cr
 
-crystal: 0.25.1
+crystal: 0.26.1
 
 license: MIT

--- a/spec/configs/dependencies.yaml
+++ b/spec/configs/dependencies.yaml
@@ -1,16 +1,16 @@
 
 job0:
-  command:
-    echo "job0"
+  commands:
+    - echo "job0"
   depends_on:
     job1
 
 job1:
-  command:
-    echo "job1"
+  commands:
+    - echo "job1"
   depends_on:
     job2
 
 job2:
-  command:
-    echo "job2"
+  commands:
+    - echo "job2"

--- a/spec/configs/error.yaml
+++ b/spec/configs/error.yaml
@@ -1,10 +1,10 @@
 
 err0:
-  command:
-    echo "OK"
+  commands:
+    - echo "OK"
   depends_on:
     err1
 
 err1:
-  command:
-    hogehoge
+  commands:
+    - hogehoge

--- a/spec/configs/ignore_error.yaml
+++ b/spec/configs/ignore_error.yaml
@@ -1,12 +1,12 @@
 
 ignore0:
-  command:
-    echo "OK"
+  commands:
+    - echo "OK"
   depends_on:
     ignore1
 
 ignore1:
-  command:
-    hogehoge
+  commands:
+    - hogehoge
   ignore_error:
     true

--- a/spec/configs/import.yaml
+++ b/spec/configs/import.yaml
@@ -3,13 +3,13 @@ import:
   - spec/configs/imported1.yaml
 
 import_main:
-  command:
-    echo "OK from import_main"
+  commands:
+    - echo "OK from import_main"
   depends_on:
     - imported0
     - imported1
     - import0
 
 import0:
-  command:
-    echo "OK from import0"
+  commands:
+    - echo "OK from import0"

--- a/spec/configs/import_single.yaml
+++ b/spec/configs/import_single.yaml
@@ -2,7 +2,7 @@ import:
   spec/configs/imported_single.yaml
 
 import_single:
-  command:
-    echo "OK from import_single"
+  commands:
+    - echo "OK from import_single"
   depends_on:
     imported_single

--- a/spec/configs/imported0.yaml
+++ b/spec/configs/imported0.yaml
@@ -1,3 +1,3 @@
 imported0:
-  command:
-    echo "OK from imported0"
+  commands:
+    - echo "OK from imported0"

--- a/spec/configs/imported1.yaml
+++ b/spec/configs/imported1.yaml
@@ -1,3 +1,3 @@
 imported1:
-  command:
-    echo "OK from imported1"
+  commands:
+    - echo "OK from imported1"

--- a/spec/configs/imported_single.yaml
+++ b/spec/configs/imported_single.yaml
@@ -1,3 +1,3 @@
 imported_single:
-  command:
-    echo "OK from imported_single"
+  commands:
+    - echo "OK from imported_single"

--- a/spec/configs/loop_jobs.yaml
+++ b/spec/configs/loop_jobs.yaml
@@ -1,6 +1,6 @@
 loop0:
-  command:
-    pwd
+  commands:
+    - pwd
   depends_on:
     loop1
 

--- a/spec/configs/main.yaml
+++ b/spec/configs/main.yaml
@@ -1,3 +1,3 @@
 main:
-  command:
-    echo "OK"
+  commands:
+    - echo "OK"

--- a/spec/configs/output.yaml
+++ b/spec/configs/output.yaml
@@ -1,6 +1,6 @@
 output:
-  command:
-    echo "The result is $RESULT"
+  commands:
+    - echo "The result is $RESULT"
   depends_on:
     -
       job: run_crystal
@@ -9,13 +9,13 @@ output:
     - just_echo
 
 run_crystal:
-  command:
-    crystal eval "puts 1 + 3"
+  commands:
+    - crystal eval "puts 1 + 3"
 
 just_echo:
-  command:
-    echo "I'm echo"
+  commands:
+    - echo "I'm echo"
 
 just_echo2:
-  command:
-    echo "I'm second echo"
+  commands:
+    - echo "I'm second echo"

--- a/spec/configs/same_name_jobs.yaml
+++ b/spec/configs/same_name_jobs.yaml
@@ -1,5 +1,5 @@
 same:
-  command:
-    pwd
+  commands:
+    - pwd
   depends_on:
     same

--- a/spec/configs/specify.yaml
+++ b/spec/configs/specify.yaml
@@ -1,10 +1,10 @@
 
 specify0:
-  command:
-    echo "OK"
+  commands:
+    - echo "OK"
   depends_on:
     specify1
 
 specify1:
-  command:
-    echo "OK"
+  commands:
+    - echo "OK"

--- a/spec/configs/up_to_date.yaml
+++ b/spec/configs/up_to_date.yaml
@@ -1,5 +1,5 @@
 up_to_date:
-  command:
-    date
+  commands:
+    - date
   src:
     src/neph.cr

--- a/src/bin/neph_bin.cr
+++ b/src/bin/neph_bin.cr
@@ -8,18 +8,19 @@ class NephBin
   CONFIG_PATH = "neph.yaml"
   @job_name : String = JOB_NAME
   @config_path : String = CONFIG_PATH
-  @mode : String = "AUTO"
+  @exec_mode : String = "parallel"
+  @log_mode : String = "AUTO"
 
   def initialize
     ready_dir
 
     parse_option!
 
-    if @mode == "AUTO"
+    if @log_mode == "AUTO"
       if STDOUT.tty?
-        @mode = "NORMAL"
+        @log_mode = "NORMAL"
       else
-        @mode = "CI"
+        @log_mode = "CI"
       end
     end
   end
@@ -42,7 +43,7 @@ class NephBin
           exit -1
         end
 
-        @mode = mode
+        @log_mode = mode
       end
 
       parser.on("-v", "--version", "Show the version") do
@@ -66,6 +67,10 @@ class NephBin
         exit 0
       end
 
+      parser.on("-s", "--seq", "Execute jobs sequentially. (Default is parallel.)") do
+        @exec_mode = "sequential"
+      end
+
       parser.unknown_args do |args|
         if args.size > 1
           log_ln "Only one job is supported yet."
@@ -83,7 +88,7 @@ class NephBin
   def exec
     main_job = parse_yaml(@job_name, @config_path)
 
-    job_executor = JobExecutor.new(main_job, @mode)
+    job_executor = JobExecutor.new(main_job, @exec_mode, @log_mode)
     job_executor.exec
   end
 

--- a/src/neph/job/job_executor.cr
+++ b/src/neph/job/job_executor.cr
@@ -1,15 +1,36 @@
 module Neph
   class JobExecutor
-    def initialize(@job : Job, @mode : String); end
+    def initialize(@job : Job, @exec_mode : String, @log_mode : String); end
 
     def exec
-      channel = Channel(Job).new
+      case @exec_mode
+      when "parallel"
+        exec_parallel
+      when "sequential"
+        exec_sequential
+      else
+        puts "Unknown execution mode: #{@exec_mode}"
+        exit -1
+      end
+
+      print_status
+    end
+
+    def exec_parallel
+      channel = Channel(Nil).new
       @start = Time.now
 
       spawn do
         @job.exec(channel)
+      end      
+    end
+
+    def exec_sequential
+      @start = Time.now
+
+      spawn do
+        @job.exec
       end
-      print_status
     end
 
     def banner : String
@@ -40,7 +61,7 @@ module Neph
     end
 
     def print_status
-      case @mode
+      case @log_mode
       when "NORMAL"
         print_status_normal
       when "CI"

--- a/src/neph/parser/parser.cr
+++ b/src/neph/parser/parser.cr
@@ -34,13 +34,23 @@ module Neph
       end
 
       job_config = config[job_name].as_h
-      job_command = if job_config.has_key?("command")
-                      job_config["command"].as_s
+      job_commands = if job_config.has_key?("commands")
+                      job_config["commands"].as_a.map { |c| c.as_s }
                     else
-                      ""
-                    end
+                      [] of String
+                     end
+      job_before = if job_config.has_key?("before")
+                     job_config["before"].as_a.map { |c| c.as_s }
+                   else
+                     [] of String
+                   end
+      job_after = if job_config.has_key?("after")
+                     job_config["after"].as_a.map { |c| c.as_s }
+                   else
+                     [] of String
+                   end
 
-      job = Job.new(job_name, job_command, parent_job)
+      job = Job.new(job_name, job_commands, job_before, job_after, parent_job)
       job.dir = job_config["dir"].as_s if job_config.has_key?("dir")
       job.ignore_error = job_config["ignore_error"] ? true : false if job_config.has_key?("ignore_error")
       job.hide = job_config["hide"] ? true : false if job_config.has_key?("hide")

--- a/src/neph/version.cr
+++ b/src/neph/version.cr
@@ -1,3 +1,3 @@
 module Neph
-  VERSION = "0.2.6"
+  VERSION = "0.2.7"
 end


### PR DESCRIPTION
There are 3 big changes.
1. Added `--seq` flag to execute jobs sequentially.
2. Added before/after steps to ready/clean execution environment.
3. command is now **commands**. And it only accepts array of String (Not String).

I'll merge and publish this release after every CI are passed.