### PR TITLE
Update to crystal 0.33

### DIFF
--- a/src/neph/job/job.cr
+++ b/src/neph/job/job.cr
@@ -136,7 +136,7 @@ module Neph
     end
 
     def time_msg : String
-      time = Time.now.to_s("%Y-%m-%d %H:%S:%M")
+      time = Time.local.to_s("%Y-%m-%d %H:%S:%M")
       "[#{time}] "
     end
 
@@ -270,7 +270,7 @@ module Neph
       stdout = File.open("#{@log_dir}/#{log_out}", "w")
       stderr = File.open("#{@log_dir}/#{log_err}", "w")
 
-      s = Time.now
+      s = Time.local
 
       exec_commands(@before, stdout, stderr)
       exec_commands(@commands, stdout, stderr)
@@ -278,7 +278,7 @@ module Neph
 
       @done_command += 1
 
-      e = Time.now
+      e = Time.local
       @elapsed_time = format_time(e - s)
       stdout.close
       stderr.close

--- a/src/neph/job/job_executor.cr
+++ b/src/neph/job/job_executor.cr
@@ -18,7 +18,7 @@ module Neph
 
     def exec_parallel
       channel = Channel(Nil).new
-      @start = Time.now
+      @start = Time.local
 
       spawn do
         @job.exec(channel)
@@ -26,7 +26,7 @@ module Neph
     end
 
     def exec_sequential
-      @start = Time.now
+      @start = Time.local
 
       spawn do
         @job.exec
@@ -120,7 +120,7 @@ module Neph
 
     def print_result
       if start = @start
-        elapsed_time = format_time(Time.now - @start.as(Time))
+        elapsed_time = format_time(Time.local - @start.as(Time))
         log_ln "\nFinished in #{elapsed_time}".colorize.mode(:bold).to_s
       end
     end


### PR DESCRIPTION
Hi @tbrand,

`Crystal` **0.33.0** has been release 3 days ago

It removes a _deprecated_ function -> `Time.now`
@see https://github.com/crystal-lang/crystal/blob/master/CHANGELOG.md#time-2

This `PR` replace `Time.now` with `Time.local`

Regards,